### PR TITLE
Dockeriza front end

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+npm install --legacy-peer-deps
+ng serve --host 0.0.0.0 --port 4200

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:18-alpine
+ARG NODE_ENV=development
+
+ENV NODE_ENV=${NODE_ENV}
+
+ARG TZ='America/Sao_Paulo'
+
+ENV TZ ${TZ}
+
+RUN apk upgrade --update \
+    && apk add --no-cache bash curl make \
+    && apk add -U tzdata \
+    && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && apk add chromium \
+    && rm -rf \
+    /var/cache/apk/*
+
+ENV CHROME_BIN='/usr/bin/chromium-browser'
+
+RUN curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | bash -s -- -b /usr/local/bin
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN npm i -g @angular/cli@15.2.6
+
+USER node
+
+WORKDIR /home/node/app
+
+COPY . .
+
+CMD ["node", "dist/main.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+services:
+  opa_frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - '.:/home/node/app'
+    entrypoint: ./.docker/entrypoint.sh
+    environment:
+      - NODE_ENV=development
+    ports:
+      - '4200:4200'
+      - '9229:9229'
+      - '9876:9876'


### PR DESCRIPTION
No meu caso eu uso o node 14.18 pro trabalho e se eu mudo a versão pro opa da problema no trabalho, então eu dockerizei o front-end para rodar o angular dentro do docker e não dar mais esse BO, contudo se você quiser não é obrigado a rodar o docker para testar as coisas